### PR TITLE
Remove postinstall script from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "Angular filter that transforms english nouns into its plural form",
   "main": "ng-pluralize-filter.js",
   "scripts": {
-    "test": "gulp",
-    "postinstall": "bower install"
+    "test": "gulp test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The postinstall script is fired after the user install this package with the command: `npm install mikaelharsjo/ngPluralizeFilter` but fails since bower is not installed.

This either drives the user to install bower (although it is not going to be fruitful) or to ignore all the scripts of the package (`npm install --ignore-scripts`).

Solution? Remove the bower install from package.json
