### PR TITLE
Changed plural for octopus and updated unit tests to reflect change

### DIFF
--- a/ng-pluralize-filter.js
+++ b/ng-pluralize-filter.js
@@ -11,7 +11,7 @@ angular.module('ngPluralizeFilter', []).filter('pluralize', function() {
     if (typeof noun !== 'string') { return noun; }
 
     var rules = [
-      {regex: /octopus/gi, suffix: 'octopusses'},
+      {regex: /octopus/gi, suffix: 'octopuses'},
       {regex: /person/gi, suffix: 'people'},
       {regex: /ox/gi, suffix: 'oxen'},
       {regex: /bison|buffalo|deer|duck|fish|moose|pike|plankton|salmon|sheep|squid|swine|trout|sheap|equipment|information|rice|money|species|series|news/i, suffix: '$&'}, // bison -> bison
@@ -24,7 +24,7 @@ angular.module('ngPluralizeFilter', []).filter('pluralize', function() {
       {regex: /$/gi, suffix: 's'} // cat -> cats
     ];
 
-    for (var i=0; i < rules.length; i++) {
+    for (var i = 0; i < rules.length; i++) {
       var rule = rules[i];
       if (noun.match(rule.regex)) {
          noun = noun.replace(rule.regex, rule.suffix);

--- a/ng-pluralize-filter.spec.js
+++ b/ng-pluralize-filter.spec.js
@@ -99,7 +99,7 @@ describe('pluralize', function() {
    it('handles other irregular plurals', function () {
      expect(pluralize('ox')).toBe('oxen');
      expect(pluralize('person')).toBe('people');
-     expect(pluralize('octopus')).toBe('octopusses');
+     expect(pluralize('octopus')).toBe('octopuses');
    });
  });
 });


### PR DESCRIPTION
There are three possible pluralizations for Octopus: 
Octopuses
Octopi
Octopodes
I've kept it of the same nature as your removing the extra S.
